### PR TITLE
Update 01_ancient_magic_values.txt

### DIFF
--- a/common/script_values/01_ancient_magic_values.txt
+++ b/common/script_values/01_ancient_magic_values.txt
@@ -46,7 +46,6 @@ mage_level = {
 
 mage_xp_to_next_level = {
 	value = mage_level
-	add = 1
 	multiply = mage_level_divider
 }
 


### PR DESCRIPTION
Remove extra addition to mage next level xp requirement

Mentioned this a bit ago, and figured I'd make the PR before I started doing too many other crazy things. Fixes the display for the xp required to level up to the next mage level.