### PR TITLE
Another perk masks fix

### DIFF
--- a/common/lifestyle_perks/01_magic_0_general_magic_perks.txt
+++ b/common/lifestyle_perks/01_magic_0_general_magic_perks.txt
@@ -45,6 +45,7 @@
 		awaken_magical_potential = yes
 		unlock_spark_spell = yes
 		give_mage_secret_or_trait_effect = yes
+		if = { limit = { has_perk_masks_trigger = no } init_perk_masks_effect = yes }
 		mod_bit = { MASK = basic_perk_mask_0 BIT = mage_perk_bit OP = set }
 		set_variable = {
 			name = mana
@@ -54,10 +55,7 @@
 			name = mage_xp
 			value = 0
 		}
-		set_variable = {
-			name = available_magic_perks
-			value = 0
-		}
-		trigger_event = { on_action = { set_up_remaining_mana_gen_for_year } }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
+		trigger_event = { on_action = set_up_remaining_mana_gen_for_year }
 	}
 }

--- a/common/lifestyle_perks/01_magic_1_time_magic_tree_perks.txt
+++ b/common/lifestyle_perks/01_magic_1_time_magic_tree_perks.txt
@@ -63,6 +63,7 @@
 		gain_mana_gen_perk = { VALUE = chronomancy_mage_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = chronomancy_mage_perk_max_mana }
 		mod_bit = { MASK = chronomancy_perk_mask_0 BIT = chronomancy_mage_perk_bit OP = set }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -129,7 +130,7 @@ glimpse_the_future_perk = {
 		gain_mana_gen_perk = { VALUE = glimpse_the_future_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = glimpse_the_future_perk_max_mana }
 		mod_bit = { MASK = chronomancy_perk_mask_0 BIT = glimpse_the_future_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -196,7 +197,7 @@ financial_times_perk = {
 		gain_mana_gen_perk = { VALUE = financial_times_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = financial_times_perk_max_mana }
 		mod_bit = { MASK = chronomancy_perk_mask_0 BIT = financial_times_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -263,7 +264,7 @@ celerity_perk = {
 		gain_mana_gen_perk = { VALUE = celerity_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = celerity_perk_max_mana }
 		mod_bit = { MASK = chronomancy_perk_mask_0 BIT = celerity_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -330,7 +331,7 @@ mass_celerity_perk = {
 		gain_mana_gen_perk = { VALUE = mass_celerity_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = mass_celerity_perk_max_mana }
 		mod_bit = { MASK = chronomancy_perk_mask_0 BIT = mass_celerity_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -397,7 +398,7 @@ slowness_perk = {
 		gain_mana_gen_perk = { VALUE = slowness_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = slowness_perk_max_mana }
 		mod_bit = { MASK = chronomancy_perk_mask_0 BIT = slowness_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -464,7 +465,7 @@ mass_slowness_perk = {
 		gain_mana_gen_perk = { VALUE = mass_slowness_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = mass_slowness_perk_max_mana }
 		mod_bit = { MASK = chronomancy_perk_mask_0 BIT = mass_slowness_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -534,7 +535,7 @@ temporal_manipulation_perk = {
 		gain_mana_gen_perk = { VALUE = temporal_manipulation_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = temporal_manipulation_perk_max_mana }
 		mod_bit = { MASK = chronomancy_perk_mask_0 BIT = temporal_manipulation_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -601,7 +602,7 @@ master_of_time_perk = {
 		gain_mana_gen_perk = { VALUE = master_of_time_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = master_of_time_perk_max_mana }
 		mod_bit = { MASK = chronomancy_perk_mask_0 BIT = master_of_time_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }

--- a/common/lifestyle_perks/01_magic_2_life_magic_tree_perks.txt
+++ b/common/lifestyle_perks/01_magic_2_life_magic_tree_perks.txt
@@ -45,7 +45,7 @@
 		gain_mana_gen_perk = { VALUE = life_mage_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = life_mage_perk_max_mana }
 		mod_bit = { MASK = life_perk_mask_0 BIT = life_mage_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -67,7 +67,7 @@ inward_reflection_perk = {
 		gain_mana_gen_perk = { VALUE = inward_reflection_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = inward_reflection_perk_max_mana }
 		mod_bit = { MASK = life_perk_mask_0 BIT = inward_reflection_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -84,7 +84,7 @@ inward_perfection_perk = {
 		gain_mana_gen_perk = { VALUE = inward_perfection_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = inward_perfection_perk_max_mana }
 		mod_bit = { MASK = life_perk_mask_0 BIT = inward_perfection_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 
@@ -108,7 +108,7 @@ heal_perk = {
 		gain_mana_gen_perk = { VALUE = heal_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = heal_perk_max_mana }
 		mod_bit = { MASK = life_perk_mask_0 BIT = heal_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -126,7 +126,7 @@ greater_heal_perk = {
 		gain_mana_gen_perk = { VALUE = greater_heal_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = greater_heal_perk_max_mana }
 		mod_bit = { MASK = life_perk_mask_0 BIT = greater_heal_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -147,7 +147,7 @@ battlefield_life_mage_perk = {
 		gain_mana_gen_perk = { VALUE = battlefield_life_mage_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = battlefield_life_mage_perk_max_mana }
 		mod_bit = { MASK = life_perk_mask_0 BIT = battlefield_life_mage_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -168,7 +168,7 @@ greater_battlefield_life_mage_perk = {
 		gain_mana_gen_perk = { VALUE = greater_battlefield_life_mage_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = greater_battlefield_life_mage_perk_max_mana }
 		mod_bit = { MASK = life_perk_mask_0 BIT = greater_battlefield_life_mage_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -192,7 +192,7 @@ purity_of_body_perk = {
 		gain_max_mana_perk = { VALUE = purity_of_body_perk_max_mana }
 		immune_to_disease_effect = yes
 		mod_bit = { MASK = life_perk_mask_0 BIT = purity_of_body_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -210,7 +210,7 @@ avatar_of_life_perk = {
 		gain_mana_gen_perk = { VALUE = avatar_of_life_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = avatar_of_life_perk_max_mana }
 		mod_bit = { MASK = life_perk_mask_0 BIT = avatar_of_life_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }

--- a/common/lifestyle_perks/01_magic_3_elemental_magic_tree_perks.txt
+++ b/common/lifestyle_perks/01_magic_3_elemental_magic_tree_perks.txt
@@ -51,7 +51,7 @@
 		gain_mana_gen_perk = { VALUE = elemental_mage_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = elemental_mage_perk_max_mana }
 		mod_bit = { MASK = elomancy_perk_mask_0 BIT = elemental_mage_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -69,7 +69,7 @@ flame_aura_perk = {
 		gain_mana_gen_perk = { VALUE = flame_aura_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = flame_aura_perk_max_mana }
 		mod_bit = { MASK = elomancy_perk_mask_0 BIT = flame_aura_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -87,7 +87,7 @@ flaming_weapons_perk = {
 		gain_mana_gen_perk = { VALUE = flaming_weapons_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = flaming_weapons_perk_max_mana }
 		mod_bit = { MASK = elomancy_perk_mask_0 BIT = flaming_weapons_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -105,7 +105,7 @@ living_earthworks_perk = {
 		gain_mana_gen_perk = { VALUE = living_earthworks_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = living_earthworks_perk_max_mana }
 		mod_bit = { MASK = elomancy_perk_mask_0 BIT = living_earthworks_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -123,7 +123,7 @@ golem_creation_perk = {
 		gain_mana_gen_perk = { VALUE = golem_creation_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = golem_creation_perk_max_mana }
 		mod_bit = { MASK = elomancy_perk_mask_0 BIT = golem_creation_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -145,7 +145,7 @@ control_water_perk = {
 		gain_mana_gen_perk = { VALUE = control_water_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = control_water_perk_max_mana }
 		mod_bit = { MASK = elomancy_perk_mask_0 BIT = control_water_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -163,7 +163,7 @@ drought_perk = {
 		gain_mana_gen_perk = { VALUE = drought_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = drought_perk_max_mana }
 		mod_bit = { MASK = elomancy_perk_mask_0 BIT = drought_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -183,7 +183,7 @@ elemental_warrior_perk = {
 		gain_mana_gen_perk = { VALUE = elemental_warrior_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = elemental_warrior_perk_max_mana }
 		mod_bit = { MASK = elomancy_perk_mask_0 BIT = elemental_warrior_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -201,7 +201,7 @@ lord_of_the_elements_perk = {
 		gain_mana_gen_perk = { VALUE = lord_of_the_elements_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = lord_of_the_elements_perk_max_mana }
 		mod_bit = { MASK = elomancy_perk_mask_0 BIT = lord_of_the_elements_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }

--- a/common/lifestyle_perks/01_magic_4_death_magic_tree_perks.txt
+++ b/common/lifestyle_perks/01_magic_4_death_magic_tree_perks.txt
@@ -63,7 +63,7 @@
 		gain_mana_gen_perk = { VALUE = death_mage_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = death_mage_perk_max_mana }
 		mod_bit = { MASK = necromancy_perk_mask_0 BIT = death_mage_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -81,7 +81,7 @@ inflict_illness_perk = {
 		gain_mana_gen_perk = { VALUE = inflict_illness_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = inflict_illness_perk_max_mana }
 		mod_bit = { MASK = necromancy_perk_mask_0 BIT = inflict_illness_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -99,7 +99,7 @@ plague_lord_perk = {
 		gain_mana_gen_perk = { VALUE = plague_lord_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = plague_lord_perk_max_mana }
 		mod_bit = { MASK = necromancy_perk_mask_0 BIT = plague_lord_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -117,7 +117,7 @@ aura_of_death_perk = {
 		gain_mana_gen_perk = { VALUE = aura_of_death_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = aura_of_death_perk_max_mana }
 		mod_bit = { MASK = necromancy_perk_mask_0 BIT = aura_of_death_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -135,7 +135,7 @@ necromancy_perk = {
 		gain_mana_gen_perk = { VALUE = necromancy_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = necromancy_perk_max_mana }
 		mod_bit = { MASK = necromancy_perk_mask_0 BIT = necromancy_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -153,7 +153,7 @@ drain_life_perk = {
 		gain_mana_gen_perk = { VALUE = drain_life_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = drain_life_perk_max_mana }
 		mod_bit = { MASK = necromancy_perk_mask_0 BIT = drain_life_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -171,7 +171,7 @@ death_stare_perk = {
 		gain_mana_gen_perk = { VALUE = death_stare_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = death_stare_perk_max_mana }
 		mod_bit = { MASK = necromancy_perk_mask_0 BIT = death_stare_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -191,7 +191,7 @@ blight_perk = {
 		gain_mana_gen_perk = { VALUE = blight_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = blight_perk_max_mana }
 		mod_bit = { MASK = necromancy_perk_mask_0 BIT = blight_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -209,7 +209,7 @@ deacon_of_death_perk = {
 		gain_mana_gen_perk = { VALUE = deacon_of_death_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = deacon_of_death_perk_max_mana }
 		mod_bit = { MASK = necromancy_perk_mask_0 BIT = deacon_of_death_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }

--- a/common/lifestyle_perks/01_magic_5_biomancy_magic_tree_perks.txt
+++ b/common/lifestyle_perks/01_magic_5_biomancy_magic_tree_perks.txt
@@ -57,7 +57,7 @@
 		gain_mana_gen_perk = { VALUE = biomancy_mage_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = biomancy_mage_perk_max_mana }
 		mod_bit = { MASK = biomancy_perk_mask_0 BIT = biomancy_mage_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -83,7 +83,7 @@ improve_trait_perk = {
 		gain_mana_gen_perk = { VALUE = improve_trait_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = improve_trait_perk_max_mana }
 		mod_bit = { MASK = biomancy_perk_mask_0 BIT = improve_trait_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -103,7 +103,7 @@ perfect_trait_perk = {
 		gain_mana_gen_perk = { VALUE = perfect_trait_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = perfect_trait_perk_max_mana }
 		mod_bit = { MASK = biomancy_perk_mask_0 BIT = perfect_trait_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -121,7 +121,7 @@ fertility_control_perk = {
 		gain_mana_gen_perk = { VALUE = fertility_control_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = fertility_control_perk_max_mana }
 		mod_bit = { MASK = biomancy_perk_mask_0 BIT = fertility_control_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -139,7 +139,7 @@ impregnate_perk = {
 		gain_mana_gen_perk = { VALUE = impregnate_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = impregnate_perk_max_mana }
 		mod_bit = { MASK = biomancy_perk_mask_0 BIT = impregnate_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -165,7 +165,7 @@ weaken_trait_perk = {
 		gain_mana_gen_perk = { VALUE = weaken_trait_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = weaken_trait_perk_max_mana }
 		mod_bit = { MASK = biomancy_perk_mask_0 BIT = weaken_trait_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -185,7 +185,7 @@ criple_trait_perk = {
 		gain_mana_gen_perk = { VALUE = criple_trait_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = criple_trait_perk_max_mana }
 		mod_bit = { MASK = biomancy_perk_mask_0 BIT = criple_trait_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -205,7 +205,7 @@ sculpter_of_flesh_perk = {
 		gain_mana_gen_perk = { VALUE = sculpter_of_flesh_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = sculpter_of_flesh_perk_max_mana }
 		mod_bit = { MASK = biomancy_perk_mask_0 BIT = sculpter_of_flesh_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -228,7 +228,7 @@ architect_of_bloodlines_perk = {
 		gain_mana_gen_perk = { VALUE = architect_of_bloodlines_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = architect_of_bloodlines_perk_max_mana }
 		mod_bit = { MASK = biomancy_perk_mask_0 BIT = architect_of_bloodlines_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }

--- a/common/lifestyle_perks/01_magic_6_domination_magic_tree_perks.txt
+++ b/common/lifestyle_perks/01_magic_6_domination_magic_tree_perks.txt
@@ -57,7 +57,7 @@
 		gain_mana_gen_perk = { VALUE = domination_mage_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = domination_mage_perk_max_mana }
 		mod_bit = { MASK = mensomancy_perk_mask_0 BIT = domination_mage_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -75,7 +75,7 @@ entrance_perk = {
 		gain_mana_gen_perk = { VALUE = entrance_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = entrance_perk_max_mana }
 		mod_bit = { MASK = mensomancy_perk_mask_0 BIT = entrance_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -93,7 +93,7 @@ incite_lust_perk = {
 		gain_mana_gen_perk = { VALUE = incite_lust_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = incite_lust_perk_max_mana }
 		mod_bit = { MASK = mensomancy_perk_mask_0 BIT = incite_lust_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -111,7 +111,7 @@ incite_obedience_perk = {
 		gain_mana_gen_perk = { VALUE = incite_obedience_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = incite_obedience_perk_max_mana }
 		mod_bit = { MASK = mensomancy_perk_mask_0 BIT = incite_obedience_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -129,7 +129,7 @@ dominate_perk = {
 		gain_mana_gen_perk = { VALUE = dominate_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = dominate_perk_max_mana }
 		mod_bit = { MASK = mensomancy_perk_mask_0 BIT = dominate_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -147,7 +147,7 @@ beguiling_aura_perk = {
 		gain_mana_gen_perk = { VALUE = beguiling_aura_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = beguiling_aura_perk_max_mana }
 		mod_bit = { MASK = mensomancy_perk_mask_0 BIT = beguiling_aura_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -166,7 +166,7 @@ friendship_perk = {
 		gain_mana_gen_perk = { VALUE = friendship_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = friendship_perk_max_mana }
 		mod_bit = { MASK = mensomancy_perk_mask_0 BIT = friendship_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -186,7 +186,7 @@ enchanting_aura_perk = {
 		gain_mana_gen_perk = { VALUE = enchanting_aura_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = enchanting_aura_perk_max_mana }
 		mod_bit = { MASK = mensomancy_perk_mask_0 BIT = enchanting_aura_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }
@@ -205,7 +205,7 @@ master_of_puppets_perk = {
 		gain_mana_gen_perk = { VALUE = master_of_puppets_perk_gen_cost }
 		gain_max_mana_perk = { VALUE = master_of_puppets_perk_max_mana }
 		mod_bit = { MASK = mensomancy_perk_mask_0 BIT = master_of_puppets_perk_bit OP = set }
-		change_variable = { name = available_magic_perks subtract = 1 }
+		set_variable = { name = available_magic_perks value = num_available_magic_perks }
 		trigger_event = { on_action = on_reset_mana_system }
 	}
 }

--- a/common/scripted_effects/magic_advancement_gui_effects.txt
+++ b/common/scripted_effects/magic_advancement_gui_effects.txt
@@ -12,34 +12,34 @@ effect_close_magic_advancement_window = {
 init_perk_masks_effect = {
 	set_variable = {
 		name = aura_mask_0
-		value = 0
+		value = aura_mask_0_maker
 	}
 	set_variable = {
 		name = basic_perk_mask_0
-		value = 0
+		value = basic_perk_mask_0_maker
 	}
 	set_variable = {
 		name = chronomancy_perk_mask_0
-		value = 0
+		value = chronomancy_perk_mask_0_maker
 	}
 	set_variable = {
 		name = life_perk_mask_0
-		value = 0
+		value = life_perk_mask_0_maker
 	}
 	set_variable = {
 		name = elomancy_perk_mask_0
-		value = 0
+		value = elomancy_perk_mask_0_maker
 	}
 	set_variable = {
 		name = necromancy_perk_mask_0
-		value = 0
+		value = necromancy_perk_mask_0_maker
 	}
 	set_variable = {
 		name = biomancy_perk_mask_0
-		value = 0
+		value = biomancy_perk_mask_0_maker
 	}
 	set_variable = {
 		name = mensomancy_perk_mask_0
-		value = 0
+		value = mensomancy_perk_mask_0_maker
 	}
 }

--- a/common/scripted_guis/magic_advancement_scripted_gui.txt
+++ b/common/scripted_guis/magic_advancement_scripted_gui.txt
@@ -27,8 +27,12 @@ toggle_magic_advancement_window = {
 		}
 		else = {
 			if = {
-				limit = { NOT = { has_variable = basic_perk_mask_0 } }
+				limit = { has_perk_masks_trigger = no }
 				init_perk_masks_effect = yes
+				set_variable = {
+					name = available_magic_perks
+					value = mage_level
+				}
 			}
 			effect_open_magic_advancement_window = yes
 		}
@@ -123,10 +127,7 @@ perk_select = {
 
 	is_valid = { # aka can_be_selected
 		AND = {
-			OR = {
-				is_magus_trigger = no # workaround to keep non-mages from throwing 62 errors per frame
-				var:available_magic_perks > 0
-			}
+			var:available_magic_perks > 0
 			has_character_modifier = magic_advancement_modifier
 			switch = {
 				trigger = scope:perk

--- a/common/scripted_triggers/01_ancient_magic_bitmask_triggers.txt
+++ b/common/scripted_triggers/01_ancient_magic_bitmask_triggers.txt
@@ -67,3 +67,14 @@ has_any_spell_aura_targets_trigger = {
 has_spell_aura_targets_trigger = {
 	var:aura_mask_0.$SPELL$_aura_bit.compare_value = set
 }
+
+has_perk_masks_trigger = {
+	has_variable = aura_mask_0
+	has_variable = basic_perk_mask_0
+	has_variable = chronomancy_perk_mask_0
+	has_variable = life_perk_mask_0
+	has_variable = elomancy_perk_mask_0
+	has_variable = necromancy_perk_mask_0
+	has_variable = biomancy_perk_mask_0
+	has_variable = mensomancy_perk_mask_0
+}


### PR DESCRIPTION
Adds yet another place where perk masks are initialized
Reinitializes available magic perk count on every selection, instead of assuming the number is correct to begin with