### PR TITLE
Yet another perk masks fix

### DIFF
--- a/common/decisions/01_magic_decisions.txt
+++ b/common/decisions/01_magic_decisions.txt
@@ -65,6 +65,10 @@ reset_mana_system_decision = {
 					has_variable = mana_gen
 				}
 			}
+			AND = {
+				is_magus_trigger = yes
+				has_perk_masks_trigger = no
+			}
 		}
 	}
 
@@ -105,38 +109,7 @@ reset_mana_system_decision = {
 						remove_perk = death_magic_8_perk
 						add_perk = blight_perk
 					}
-					set_variable = {
-						name = aura_mask_0
-						value = 0
-					}
-					set_variable = {
-						name = basic_perk_mask_0
-						value = basic_perk_mask_0_maker
-					}
-					set_variable = {
-						name = chronomancy_perk_mask_0
-						value = chronomancy_perk_mask_0_maker
-					}
-					set_variable = {
-						name = life_perk_mask_0
-						value = life_perk_mask_0_maker
-					}
-					set_variable = {
-						name = elomancy_perk_mask_0
-						value = elomancy_perk_mask_0_maker
-					}
-					set_variable = {
-						name = necromancy_perk_mask_0
-						value = necromancy_perk_mask_0_maker
-					}
-					set_variable = {
-						name = biomancy_perk_mask_0
-						value = biomancy_perk_mask_0_maker
-					}
-					set_variable = {
-						name = mensomancy_perk_mask_0
-						value = mensomancy_perk_mask_0_maker
-					}
+					init_perk_masks_effect = yes
 					remove_character_flag = magic_potential_1_mana_added
 					remove_character_flag = magic_potential_2_mana_added
 					remove_character_flag = magic_potential_3_mana_added

--- a/common/lifestyle_perks/01_magic_0_general_magic_perks.txt
+++ b/common/lifestyle_perks/01_magic_0_general_magic_perks.txt
@@ -56,6 +56,7 @@
 			value = 0
 		}
 		set_variable = { name = available_magic_perks value = num_available_magic_perks }
+		trigger_event = { on_action = on_reset_mana_system }
 		trigger_event = { on_action = set_up_remaining_mana_gen_for_year }
 	}
 }

--- a/common/on_action/01_ancient_magic_mana_system_on_actions.txt
+++ b/common/on_action/01_ancient_magic_mana_system_on_actions.txt
@@ -10,6 +10,7 @@ yearly_mana_pulse = {
 			limit = { has_game_rule = am_magic_gen_daily }
 			every_living_character = {
 				limit = { is_magus_trigger = yes }
+				if = { limit = { has_perk_masks_trigger = no } init_perk_masks_effect = yes }
 				set_variable = {
 					name = mana_gen_days_left
 					value = 365
@@ -20,6 +21,7 @@ yearly_mana_pulse = {
 		else = {
 			every_living_character = {
 				limit = { is_magus_trigger = yes }
+				if = { limit = { has_perk_masks_trigger = no } init_perk_masks_effect = yes }
 				set_variable = {
 					name = mana_gen_months_left
 					value = 12

--- a/common/scripted_effects/01_ancient_magic_bitmask_effects.txt
+++ b/common/scripted_effects/01_ancient_magic_bitmask_effects.txt
@@ -1,20 +1,14 @@
 ﻿# Valid OPs: flip, set, unset
 mod_bit = {
 	if = {
-		limit = { NOT = {exists = var:$MASK$ } }
+		limit = { NOT = { exists = var:$MASK$ } }
 		set_variable = {
 			name = $MASK$
-			value = 0
+			value = $MASK$_maker
 		}
 	}
 	set_variable = {
 		name = $MASK$
 		value = var:$MASK$.$BIT$_$OP$
 	}
-}
-
-add_perk_from_school_effect = {
-	add_perk = $PERK$
-	mod_bit = { MASK = $SCHOOL$_perk_mask_0 BIT = $PERK$_bit OP = set }
-	trigger_event = { on_action = on_reset_mana_system }
 }

--- a/common/scripted_guis/magic_advancement_scripted_gui.txt
+++ b/common/scripted_guis/magic_advancement_scripted_gui.txt
@@ -194,61 +194,61 @@ perk_select = {
 	effect = {
 		switch = {
 			trigger = scope:perk
-			flag:mage_perk = { add_perk_from_school_effect = { SCHOOL = none PERK = mage_perk } }
-			flag:chronomancy_mage_perk = { add_perk_from_school_effect = { SCHOOL = chronomancy PERK = chronomancy_mage_perk } }
-			flag:glimpse_the_future_perk = { add_perk_from_school_effect = { SCHOOL = chronomancy PERK = glimpse_the_future_perk } }
-			flag:financial_times_perk = { add_perk_from_school_effect = { SCHOOL = chronomancy PERK = financial_times_perk } }
-			flag:celerity_perk = { add_perk_from_school_effect = { SCHOOL = chronomancy PERK = celerity_perk } }
-			flag:mass_celerity_perk = { add_perk_from_school_effect = { SCHOOL = chronomancy PERK = mass_celerity_perk } }
-			flag:slowness_perk = { add_perk_from_school_effect = { SCHOOL = chronomancy PERK = slowness_perk } }
-			flag:mass_slowness_perk = { add_perk_from_school_effect = { SCHOOL = chronomancy PERK = mass_slowness_perk } }
-			flag:temporal_manipulation_perk = { add_perk_from_school_effect = { SCHOOL = chronomancy PERK = temporal_manipulation_perk } }
-			flag:master_of_time_perk = { add_perk_from_school_effect = { SCHOOL = chronomancy PERK = master_of_time_perk } }
-			flag:life_mage_perk = { add_perk_from_school_effect = { SCHOOL = life PERK = life_mage_perk } }
-			flag:inward_reflection_perk = { add_perk_from_school_effect = { SCHOOL = life PERK = inward_reflection_perk } }
-			flag:inward_perfection_perk = { add_perk_from_school_effect = { SCHOOL = life PERK = inward_perfection_perk } }
-			flag:heal_perk = { add_perk_from_school_effect = { SCHOOL = life PERK = heal_perk } }
-			flag:greater_heal_perk = { add_perk_from_school_effect = { SCHOOL = life PERK = greater_heal_perk } }
-			flag:battlefield_life_mage_perk = { add_perk_from_school_effect = { SCHOOL = life PERK = battlefield_life_mage_perk } }
-			flag:greater_battlefield_life_mage_perk = { add_perk_from_school_effect = { SCHOOL = life PERK = greater_battlefield_life_mage_perk } }
-			flag:purity_of_body_perk = { add_perk_from_school_effect = { SCHOOL = life PERK = purity_of_body_perk } }
-			flag:avatar_of_life_perk = { add_perk_from_school_effect = { SCHOOL = life PERK = avatar_of_life_perk } }
-			flag:elemental_mage_perk = { add_perk_from_school_effect = { SCHOOL = elomancy PERK = elemental_mage_perk } }
-			flag:flame_aura_perk = { add_perk_from_school_effect = { SCHOOL = elomancy PERK = flame_aura_perk } }
-			flag:flaming_weapons_perk = { add_perk_from_school_effect = { SCHOOL = elomancy PERK = flaming_weapons_perk } }
-			flag:living_earthworks_perk = { add_perk_from_school_effect = { SCHOOL = elomancy PERK = living_earthworks_perk } }
-			flag:golem_creation_perk = { add_perk_from_school_effect = { SCHOOL = elomancy PERK = golem_creation_perk } }
-			flag:control_water_perk = { add_perk_from_school_effect = { SCHOOL = elomancy PERK = control_water_perk } }
-			flag:drought_perk = { add_perk_from_school_effect = { SCHOOL = elomancy PERK = drought_perk } }
-			flag:elemental_warrior_perk = { add_perk_from_school_effect = { SCHOOL = elomancy PERK = elemental_warrior_perk } }
-			flag:lord_of_the_elements_perk = { add_perk_from_school_effect = { SCHOOL = elomancy PERK = lord_of_the_elements_perk } }
-			flag:death_mage_perk = { add_perk_from_school_effect = { SCHOOL = necromancy PERK = death_mage_perk } }
-			flag:inflict_illness_perk = { add_perk_from_school_effect = { SCHOOL = necromancy PERK = inflict_illness_perk } }
-			flag:plague_lord_perk = { add_perk_from_school_effect = { SCHOOL = necromancy PERK = plague_lord_perk } }
-			flag:aura_of_death_perk = { add_perk_from_school_effect = { SCHOOL = necromancy PERK = aura_of_death_perk } }
-			flag:necromancy_perk = { add_perk_from_school_effect = { SCHOOL = necromancy PERK = necromancy_perk } }
-			flag:drain_life_perk = { add_perk_from_school_effect = { SCHOOL = necromancy PERK = drain_life_perk } }
-			flag:death_stare_perk = { add_perk_from_school_effect = { SCHOOL = necromancy PERK = death_stare_perk } }
-			flag:blight_perk = { add_perk_from_school_effect = { SCHOOL = necromancy PERK = blight_perk } }
-			flag:deacon_of_death_perk = { add_perk_from_school_effect = { SCHOOL = necromancy PERK = deacon_of_death_perk } }
-			flag:biomancy_mage_perk = { add_perk_from_school_effect = { SCHOOL = biomancy PERK = biomancy_mage_perk } }
-			flag:improve_trait_perk = { add_perk_from_school_effect = { SCHOOL = biomancy PERK = improve_trait_perk } }
-			flag:perfect_trait_perk = { add_perk_from_school_effect = { SCHOOL = biomancy PERK = perfect_trait_perk } }
-			flag:fertility_control_perk = { add_perk_from_school_effect = { SCHOOL = biomancy PERK = fertility_control_perk } }
-			flag:impregnate_perk = { add_perk_from_school_effect = { SCHOOL = biomancy PERK = impregnate_perk } }
-			flag:weaken_trait_perk = { add_perk_from_school_effect = { SCHOOL = biomancy PERK = weaken_trait_perk } }
-			flag:criple_trait_perk = { add_perk_from_school_effect = { SCHOOL = biomancy PERK = criple_trait_perk } }
-			flag:sculpter_of_flesh_perk = { add_perk_from_school_effect = { SCHOOL = biomancy PERK = sculpter_of_flesh_perk } }
-			flag:architect_of_bloodlines_perk = { add_perk_from_school_effect = { SCHOOL = biomancy PERK = architect_of_bloodlines_perk } }
-			flag:domination_mage_perk = { add_perk_from_school_effect = { SCHOOL = mensomancy PERK = domination_mage_perk } }
-			flag:entrance_perk = { add_perk_from_school_effect = { SCHOOL = mensomancy PERK = entrance_perk } }
-			flag:incite_lust_perk = { add_perk_from_school_effect = { SCHOOL = mensomancy PERK = incite_lust_perk } }
-			flag:incite_obedience_perk = { add_perk_from_school_effect = { SCHOOL = mensomancy PERK = incite_obedience_perk } }
-			flag:dominate_perk = { add_perk_from_school_effect = { SCHOOL = mensomancy PERK = dominate_perk } }
-			flag:beguiling_aura_perk = { add_perk_from_school_effect = { SCHOOL = mensomancy PERK = beguiling_aura_perk } }
-			flag:friendship_perk = { add_perk_from_school_effect = { SCHOOL = mensomancy PERK = friendship_perk } }
-			flag:enchanting_aura_perk = { add_perk_from_school_effect = { SCHOOL = mensomancy PERK = enchanting_aura_perk } }
-			flag:master_of_puppets_perk = { add_perk_from_school_effect = { SCHOOL = mensomancy PERK = master_of_puppets_perk } }
+			flag:mage_perk = { add_perk = mage_perk }
+			flag:chronomancy_mage_perk = { add_perk = chronomancy_mage_perk }
+			flag:glimpse_the_future_perk = { add_perk = glimpse_the_future_perk }
+			flag:financial_times_perk = { add_perk = financial_times_perk }
+			flag:celerity_perk = { add_perk = celerity_perk }
+			flag:mass_celerity_perk = { add_perk = mass_celerity_perk }
+			flag:slowness_perk = { add_perk = slowness_perk }
+			flag:mass_slowness_perk = { add_perk = mass_slowness_perk }
+			flag:temporal_manipulation_perk = { add_perk = temporal_manipulation_perk }
+			flag:master_of_time_perk = { add_perk = master_of_time_perk }
+			flag:life_mage_perk = { add_perk = life_mage_perk }
+			flag:inward_reflection_perk = { add_perk = inward_reflection_perk }
+			flag:inward_perfection_perk = { add_perk = inward_perfection_perk }
+			flag:heal_perk = { add_perk = heal_perk }
+			flag:greater_heal_perk = { add_perk = greater_heal_perk }
+			flag:battlefield_life_mage_perk = { add_perk = battlefield_life_mage_perk }
+			flag:greater_battlefield_life_mage_perk = { add_perk = greater_battlefield_life_mage_perk }
+			flag:purity_of_body_perk = { add_perk = purity_of_body_perk }
+			flag:avatar_of_life_perk = { add_perk = avatar_of_life_perk }
+			flag:elemental_mage_perk = { add_perk = elemental_mage_perk }
+			flag:flame_aura_perk = { add_perk = flame_aura_perk }
+			flag:flaming_weapons_perk = { add_perk = flaming_weapons_perk }
+			flag:living_earthworks_perk = { add_perk = living_earthworks_perk }
+			flag:golem_creation_perk = { add_perk = golem_creation_perk }
+			flag:control_water_perk = { add_perk = control_water_perk }
+			flag:drought_perk = { add_perk = drought_perk }
+			flag:elemental_warrior_perk = { add_perk = elemental_warrior_perk }
+			flag:lord_of_the_elements_perk = { add_perk = lord_of_the_elements_perk }
+			flag:death_mage_perk = { add_perk = death_mage_perk }
+			flag:inflict_illness_perk = { add_perk = inflict_illness_perk }
+			flag:plague_lord_perk = { add_perk = plague_lord_perk }
+			flag:aura_of_death_perk = { add_perk = aura_of_death_perk }
+			flag:necromancy_perk = { add_perk = necromancy_perk }
+			flag:drain_life_perk = { add_perk = drain_life_perk }
+			flag:death_stare_perk = { add_perk = death_stare_perk }
+			flag:blight_perk = { add_perk = blight_perk }
+			flag:deacon_of_death_perk = { add_perk = deacon_of_death_perk }
+			flag:biomancy_mage_perk = { add_perk = biomancy_mage_perk }
+			flag:improve_trait_perk = { add_perk = improve_trait_perk }
+			flag:perfect_trait_perk = { add_perk = perfect_trait_perk }
+			flag:fertility_control_perk = { add_perk = fertility_control_perk }
+			flag:impregnate_perk = { add_perk = impregnate_perk }
+			flag:weaken_trait_perk = { add_perk = weaken_trait_perk }
+			flag:criple_trait_perk = { add_perk = criple_trait_perk }
+			flag:sculpter_of_flesh_perk = { add_perk = sculpter_of_flesh_perk }
+			flag:architect_of_bloodlines_perk = { add_perk = architect_of_bloodlines_perk }
+			flag:domination_mage_perk = { add_perk = domination_mage_perk }
+			flag:entrance_perk = { add_perk = entrance_perk }
+			flag:incite_lust_perk = { add_perk = incite_lust_perk }
+			flag:incite_obedience_perk = { add_perk = incite_obedience_perk }
+			flag:dominate_perk = { add_perk = dominate_perk }
+			flag:beguiling_aura_perk = { add_perk = beguiling_aura_perk }
+			flag:friendship_perk = { add_perk = friendship_perk }
+			flag:enchanting_aura_perk = { add_perk = enchanting_aura_perk }
+			flag:master_of_puppets_perk = { add_perk = master_of_puppets_perk }
 		}
 	}
 }


### PR DESCRIPTION
Yearly regen setup now sets masks if they don't exist
---This is slow. I am not proud of this fix, but the game insists on giving perks to characters without doing their effect blocks, so this is the best I can do for now
mod_bit now sets the mask properly instead of setting it to 0
Debug decision now checks for masks and uses the scripted effect to set them
Adding perks to the player now relies on the perk's effect block to do mask maintenance, so it doesn't happen twice