### PR TITLE
Aura maintenance fix

### DIFF
--- a/common/on_action/01_ancient_magic_mana_system_on_actions.txt
+++ b/common/on_action/01_ancient_magic_mana_system_on_actions.txt
@@ -10,7 +10,6 @@ yearly_mana_pulse = {
 			limit = { has_game_rule = am_magic_gen_daily }
 			every_living_character = {
 				limit = { is_magus_trigger = yes }
-				if = { limit = { has_perk_masks_trigger = no } init_perk_masks_effect = yes }
 				set_variable = {
 					name = mana_gen_days_left
 					value = 365
@@ -21,7 +20,6 @@ yearly_mana_pulse = {
 		else = {
 			every_living_character = {
 				limit = { is_magus_trigger = yes }
-				if = { limit = { has_perk_masks_trigger = no } init_perk_masks_effect = yes }
 				set_variable = {
 					name = mana_gen_months_left
 					value = 12

--- a/common/on_action/magic_on_actions.txt
+++ b/common/on_action/magic_on_actions.txt
@@ -54,8 +54,9 @@ reset_spell_drain = {
 	effect = {
 		every_living_character = {
 			limit = {
-				NOT = { this = prev } # If this is the dying character, we don't care about their mana gen
+				is_magus_trigger = yes
 				has_any_spell_aura_targets_trigger = yes
+				NOT = { this = prev } # If this is the dying character, we don't care about their mana gen
 			}
 			remove_prev_from_this_aura_spell_targets_effect = { SPELL = glimpse_the_future_spell }
 			remove_prev_from_this_aura_spell_targets_effect = { SPELL = financial_times_spell }

--- a/common/scripted_triggers/01_ancient_magic_bitmask_triggers.txt
+++ b/common/scripted_triggers/01_ancient_magic_bitmask_triggers.txt
@@ -61,10 +61,12 @@
 }
 
 has_any_spell_aura_targets_trigger = {
+	has_variable = aura_mask_0
 	var:aura_mask_0.compare_value > 0
 }
 
 has_spell_aura_targets_trigger = {
+	has_variable = aura_mask_0
 	var:aura_mask_0.$SPELL$_aura_bit.compare_value = set
 }
 

--- a/common/scripted_triggers/01_ancient_magic_bitmask_triggers.txt
+++ b/common/scripted_triggers/01_ancient_magic_bitmask_triggers.txt
@@ -61,12 +61,10 @@
 }
 
 has_any_spell_aura_targets_trigger = {
-	has_variable = aura_mask_0
 	var:aura_mask_0.compare_value > 0
 }
 
 has_spell_aura_targets_trigger = {
-	has_variable = aura_mask_0
 	var:aura_mask_0.$SPELL$_aura_bit.compare_value = set
 }
 

--- a/common/scripted_triggers/01_ancient_magic_triggers.txt
+++ b/common/scripted_triggers/01_ancient_magic_triggers.txt
@@ -1,8 +1,5 @@
 ﻿is_magus_trigger = {
-	OR = {
-		has_trait = mage
-		any_secret = { secret_type = secret_mage }
-	}
+	has_perk = mage_perk
 }
 
 is_magic_aura_trigger = {

--- a/common/traits/01_ancient_magic_traits.txt
+++ b/common/traits/01_ancient_magic_traits.txt
@@ -105,6 +105,10 @@ master_of_puppets = {
 mage = {
 	index = 33302
 
+	inherit_chance = 0
+	birth = 0
+	random_creation = 0
+
 	same_opinion = 20
 
 	ruler_designer_cost = 10


### PR DESCRIPTION
Triggers now check if the mask exists before checking its value
Death maintenance now checks if characters are magi before trying to do aura maintenance on them